### PR TITLE
Added argparse functionality to the wrapper

### DIFF
--- a/wrapper/__main__.py
+++ b/wrapper/__main__.py
@@ -47,11 +47,11 @@ if __name__ == '__main__':
     action = par_args.command
 
     # Generate game options
-    if  action == 'generate' or action == 'g':
+    if  action in ['generate', 'g']:
         generate()
     
     # Run game options
-    elif action == 'run' or action == 'r':
+    elif action in ['run', 'r']:
         # Additional args
         quiet = False
 
@@ -67,7 +67,7 @@ if __name__ == '__main__':
         loop(quiet)
     
     # Visualizer options
-    elif action == 'visualizer' or action == 'v':
+    elif action in ['visualizer', 'v']:
         # importing in the middle of a file is not good practice but it's done here to quiet pygame for non-visualizer options
         from game.visualizer import start
         
@@ -92,7 +92,7 @@ if __name__ == '__main__':
         start(gamma, full, endgame)
         
     # Boot up the scrimmage server client
-    elif action == 'scrimmage' or action == 's':
+    elif action in ['scrimmage', 's']:
         cl = Client()
 
     # Print help if no arguments are passed


### PR DESCRIPTION
I made the command line interface that the competitors will be using to interact with launcher.pyz a little bit less touchy. The main arguments and all optional arguments can be run either by typing out their full name or just using the first letter. The wrapper will display the main help message if no arguments are passed, and there are also additional help messages for run and visualizer that display their optional arguments. I wasn't entirely sure what the gamma ranges were for Cocos2d (I couldn't find it on the docs) so I just assumed 0 to 1 for the moment. Let me know if that isn't correct.