### PR TITLE
Upgrading city now upgrades max structure. Fixed off-by-one level eff…

### DIFF
--- a/game/common/building.py
+++ b/game/common/building.py
@@ -1,6 +1,7 @@
 from game.common.game_object import GameObject
 from game.common.enums import ObjectType, BuildingLevel, BuildingType
 from game.utils.helpers import enum_to_string
+from game.common.stats import GameStats
 
 
 # Side buildings that can be upgraded to provide various effects
@@ -10,7 +11,7 @@ class Building(GameObject):
         self.building_type = building_type
         self.object_type = ObjectType.building
         self.level = BuildingLevel.level_zero
-        self.effort_remaining = 0
+        self.effort_remaining = GameStats.building_upgrade_cost[BuildingLevel.level_one]
 
     def to_json(self):
         data = super().to_json()

--- a/game/common/city.py
+++ b/game/common/city.py
@@ -12,11 +12,9 @@ class City(GameObject):
         self.city_name = "City"
         self.object_type = ObjectType.city
         self.structure = GameStats.city_structure
-        self.max_structure = self.structure
+        self.max_structure = GameStats.city_max_structure[CityLevel.level_zero]
         self.population = GameStats.city_population
         self.gold = GameStats.city_gold
-        self.resources = GameStats.resources
-        self.location = CityLocation.plains
         self.sensors = dict()
         for sens_type in enum_iter(SensorType):
             sens = Sensor()
@@ -41,8 +39,6 @@ class City(GameObject):
         data['max_structure'] = self.max_structure
         data['population'] = self.population
         data['gold'] = self.gold
-        data['resources'] = self.resources
-        data['location'] = self.location
         data['sensors'] = {sensor_type: sensor.to_json() for sensor_type, sensor in self.sensors.items()}
         data['buildings'] = {building_type: building.to_json() for building_type, building in self.buildings.items()}
         data['remaining_man_power'] = self.remaining_man_power
@@ -59,8 +55,6 @@ class City(GameObject):
         self.max_structure = data['max_structure']
         self.population = data['population']
         self.gold = data['gold']
-        self.resources = data['resources']
-        self.location = data['location']
 
         self.sensors = dict()
         for sensor_type, sensor_data in data['sensors'].items():
@@ -83,7 +77,6 @@ class City(GameObject):
             Structure: {self.structure}
             Population: {self.population}
             Gold: {self.gold}
-            Resources: {self.resources}
             Level: {self.level}
             Object Type: {self.object_type}
             """

--- a/game/common/enums.py
+++ b/game/common/enums.py
@@ -10,14 +10,7 @@ class CityLevel:
     level_zero = 0
     level_one = 1
     level_two = 2
-
-
-class CityLocation:
-    plains = 0
-    desert = 1
-    mountains = 2
-    coastal = 3
-    radioactive_wasteland = 4
+    level_three = 3
 
 
 class CityType:
@@ -25,6 +18,9 @@ class CityType:
     healthy = 1
     sturdy = 2
     invested = 3
+    pyrophobic = 4
+    popular = 5
+    modern = 6
 
 
 class DamageScaling:

--- a/game/common/sensor.py
+++ b/game/common/sensor.py
@@ -10,7 +10,7 @@ class Sensor(GameObject):
         self.sensor_type = None
         self.object_type = ObjectType.sensor
         self.level = SensorLevel.level_zero
-        self.effort_remaining = GameStats.sensor_effort[SensorLevel.level_one]
+        self.effort_remaining = GameStats.sensor_upgrade_cost[SensorLevel.level_one]
         self.sensor_results = None
 
     def to_json(self):

--- a/game/common/stats.py
+++ b/game/common/stats.py
@@ -4,7 +4,7 @@ from game.common.enums import *
 class GameStats:
 
     # cost in man_power to upgrade a building
-    building_effort = {
+    building_upgrade_cost = {
         BuildingLevel.level_zero: 0,
         BuildingLevel.level_one: 50,
         BuildingLevel.level_two: 100,
@@ -15,7 +15,16 @@ class GameStats:
     city_upgrade_cost = {
         CityLevel.level_zero: 0,
         CityLevel.level_one: 100,
-        CityLevel.level_two: 300
+        CityLevel.level_two: 300,
+        CityLevel.level_three: 500
+    }
+
+    # cost in man_power to build a sensor
+    sensor_upgrade_cost = {
+        SensorLevel.level_zero: 0,
+        SensorLevel.level_one: 50,
+        SensorLevel.level_two: 100,
+        SensorLevel.level_three: 500
     }
 
     # Decree effectiveness when applied against a disaster
@@ -114,36 +123,25 @@ class GameStats:
     # When converting effort to one of the below, multiply the effort amount by the multiplier
     # Keep multiplier above 0 and close to 1
     effort_gold_multiplier = 1
-    effort_population_multiplier = 1
+    effort_population_multiplier = 0.5
     effort_structure_multiplier = 1
 
-    # population
-    city_population = 100
+    # starting city population
+    city_population = 40
 
-    # health
-    city_structure = 200
-
-    # resources
-    resources = 100
+    # starting city health
+    city_structure = 100
 
     # gold
-    city_gold = 100
+    city_gold = 0
     city_gold_accumulative = 1
 
-    # cost in gold to build a sensor
-    sensor_costs = {
-        SensorLevel.level_zero: 0,
-        SensorLevel.level_one: 100,
-        SensorLevel.level_two: 500,
-        SensorLevel.level_three: 1000
-    }
-
-    # cost in man_power to build a sensor
-    sensor_effort = {
-        SensorLevel.level_zero: 0,
-        SensorLevel.level_one: 50,
-        SensorLevel.level_two: 100,
-        SensorLevel.level_three: 500
+    # Max structure based on city level
+    city_max_structure = {
+        CityLevel.level_zero: 200,
+        CityLevel.level_one: 225,
+        CityLevel.level_two: 275,
+        CityLevel.level_three: 350
     }
 
     # error range provided by each sensor

--- a/game/controllers/city_generator_controller.py
+++ b/game/controllers/city_generator_controller.py
@@ -1,4 +1,5 @@
 from game.common.enums import *
+from game.common.stats import GameStats
 from game.controllers.controller import Controller
 from game.config import *
 
@@ -11,9 +12,26 @@ class CityGeneratorController(Controller):
         if city_type is CityType.none:
             pass
         elif city_type is CityType.healthy:
-            player.city.population += 50
+            # Start with population up to structure
+            player.city.population = player.city.structure
         elif city_type is CityType.sturdy:
-            player.city.structure += 50
+            # Start with structure up to max structure
+            player.city.structure = player.city.max_structure
         elif city_type is CityType.invested:
-            player.city.resources += 25
-            player.city.gold += 25
+            # Start with boosted gold
+            player.city.gold += 200
+        elif city_type is CityType.pyrophobic:
+            # Upgrade the fire sensors to level one
+            fire_alarm = player.city.sensors[SensorType.fire_alarm]
+            fire_alarm.level = SensorLevel.level_one
+            fire_alarm.effort_remaining = GameStats.sensor_upgrade_cost[SensorLevel.level_two]
+        elif city_type is CityType.popular:
+            # Upgrade the population booster building to level one
+            population_booster = player.city.buildings[BuildingType.population_booster]
+            population_booster.level = BuildingLevel.level_one
+            population_booster.effort_remaining = GameStats.building_upgrade_cost[BuildingLevel.level_two]
+        elif city_type is CityType.modern:
+            # Upgrade the city to level one
+            city = player.city
+            city.level = CityLevel.level_one
+            city.effort_remaining = GameStats.city_upgrade_cost[CityLevel.level_two]

--- a/game/testing/tests/test_efforts.py
+++ b/game/testing/tests/test_efforts.py
@@ -38,16 +38,16 @@ class TestEfforts(unittest.TestCase):
         self.test_effort_controller.handle_actions(self.player)
         for sensor in self.player.city.sensors.values():
             self.assertEqual(sensor.effort_remaining,
-                             GameStats.sensor_effort[SensorLevel.level_one] - TEST_SENSOR_AMOUNT)
+                             GameStats.sensor_upgrade_cost[SensorLevel.level_one] - TEST_SENSOR_AMOUNT)
 
     def test_population(self):
         TEST_POPULATION_AMOUNT = 20
-        self.player.city.population = 100
+        self.player.city.population = 50
         self.player.action.add_effort(ActionType.regain_population, TEST_POPULATION_AMOUNT)
 
         self.test_effort_controller.handle_actions(self.player)
         self.assertEqual(self.player.city.population,
-                         math.floor(GameStats.effort_population_multiplier * TEST_POPULATION_AMOUNT) + 100)
+                         math.floor(GameStats.effort_population_multiplier * TEST_POPULATION_AMOUNT) + 50)
 
     def test_structure(self):
         TEST_STRUCTURE_AMOUNT = 20

--- a/game/testing/tests/test_sensors.py
+++ b/game/testing/tests/test_sensors.py
@@ -44,10 +44,10 @@ class TestSensors(unittest.TestCase):
         player = Player()
         player.action = Action()
         player.city = City()
+        player.city.population = 1000
         fire_sensor = player.city.sensors[SensorType.fire_alarm]
 
         self.assertEqual(fire_sensor.level, SensorLevel.level_zero)
-
         player.action.add_effort(fire_sensor, 50)
         self.test_effort_controller.handle_actions(player)
         self.assertEqual(fire_sensor.level, SensorLevel.level_one)

--- a/game/visualizer/location_sprites.py
+++ b/game/visualizer/location_sprites.py
@@ -1,4 +1,6 @@
 import cocos
+
+
 # Display the background picture depending on the logs
 class LocationLayer(cocos.layer.Layer):
     def __init__(self, turn_info, display_size, assets):
@@ -7,10 +9,7 @@ class LocationLayer(cocos.layer.Layer):
         self.images = assets
         super().__init__()
 
-        # Retrieve the player's 'location'(background) from logs
-        image = str(self.info['player'].get('city').get('location'))
-
         # Find correlating sprite in sprite dictionary
-        location = self.images[image]
+        location = self.images["0"]
         location.position = self.display[0]/2, self.display[1]/2
         self.add(location)


### PR DESCRIPTION
…ort costs for all upgradable objects. Removed unused code. 

Before, max structure never changed when city was upgraded. Now this commit should fix that. 
Population and structure are now set at 40 and 100 to start, respectively. 
References to location were removed on the game rules end (visualizer was modified slightly to prevent crash).
References to resources were removed on the game rules end.
Enhanced builder client (max_turn_bois code). Now should run without crashing.
After leveling up an object, the wrong upgrade cost was grabbed for the next level. This should now be fixed.
Test files also updated
